### PR TITLE
Show information for all projects

### DIFF
--- a/lumi_allocations/cli.py
+++ b/lumi_allocations/cli.py
@@ -2,6 +2,7 @@
 
 from .data import ProjectInfo
 import argparse
+import os
 
 
 def main():
@@ -15,8 +16,24 @@ def main():
         help="Project numbers comma seperated. Default: all of your projects",
         default="",
     )
+    parser.add_argument(
+        "-a",
+        "--all",
+        help="Return information for all projects.",
+        action="store_true",
+    )
     parser.add_argument("--lust", action="store_true", help="Special flag for LUST")
     args = parser.parse_args()
-    projects = [] if args.projects == "" else args.projects.split(",")
+    projdir = "/projappl"
+    projects = []
+    not_a_project = {"project_462000009": False, "project_465000002": False}
+    if args.all is True:
+        # get all projects through listing /projappl and filtering out non-existing projects
+        for path in os.listdir(projdir):
+            if os.path.islink(os.path.join(projdir, path)) and path not in not_a_project:
+                projects.append(path)
+        projects.sort()
+    else:
+        projects = [] if args.projects == "" else args.projects.split(",")
     info = ProjectInfo(projects, args.lust)
     info.printQuotas()


### PR DESCRIPTION
Adds a parameter `-a` / `--all` that can be used to show information for all projects. Non-existing projects are filtered out (hardcoded).