### PR TITLE
Add qpu seconds

### DIFF
--- a/lumi_allocations/data.py
+++ b/lumi_allocations/data.py
@@ -36,14 +36,15 @@ class ProjectInfo:
 
     def printQuotas(self):
         print(
-            f"{'Project': <20}|{'CPU (used/allocated)':>40}|{'GPU (used/allocated)': >35}|{'Storage (used/allocated)':>30}"
+            f"{'Project': <20}|{'CPU (used/allocated)':>40}|{'GPU (used/allocated)': >35}|{'Storage (used/allocated)':>30}|{'QPU (used/allocated)':>40}"
         )
-        print("-" * 128)
+        print("-" * 169)
         for project in self._projects:
             billing_data = self._data[project]["billing"]
             storage_hours = billing_data["storage_hours"]
             cpu_hours = billing_data["cpu_hours"]
             gpu_hours = billing_data["gpu_hours"]
+            qpu_secs = billing_data["qpu_secs"]
             print(
-                f"{project: <20}|{self._makeQuotaString(cpu_hours, 'core/hours'): >40}|{self._makeQuotaString(gpu_hours, 'gpu/hours'): >35}|{self._makeQuotaString(storage_hours, 'TB/hours'): >30}"
+                f"{project: <20}|{self._makeQuotaString(cpu_hours, 'core/hours'): >40}|{self._makeQuotaString(gpu_hours, 'gpu/hours'): >35}|{self._makeQuotaString(storage_hours, 'TB/hours'): >30}|{self._makeQuotaString(qpu_secs, 'qpu/seconds'): >40}"
             )

--- a/lumi_allocations/tests/patches.py
+++ b/lumi_allocations/tests/patches.py
@@ -17,6 +17,10 @@ def gen_data():
                 "used": 1,
                 "alloc": 2,
             },
+            "qpu_secs": {
+                "used": 1,
+                "alloc": 2,
+            },
             "storage_hours": {
                 "used": 1,
                 "alloc": 2,

--- a/lumi_allocations/tests/project_test/project_test.json
+++ b/lumi_allocations/tests/project_test/project_test.json
@@ -9,6 +9,10 @@
       "alloc": 1000,
       "used": 500
     },
+    "qpu_secs": {
+      "alloc": 0,
+      "used": 0
+    },
     "storage_hours": {
       "alloc": 1000,
       "used": 250


### PR DESCRIPTION
QPU Seconds is listed as a billing unit in the `.json` files and it would be useful for the Quantum Users. Therefore I suggest adding it to the script. 

Only a small handful of projects have `qpu_secs` however. If it would confuse the majority of users or not be that useful to be printed for every user,  I would suggest adding a check in the script. If a project has >0 `qpu_secs` then add it to the table if not then don't add it. The implementation of this change would be larger than what is currently in the PR and that work is not included in the PR. 

- Added `qpu_secs` to `data.py` and adjusted the formatting to stdout.
- Adjusted the tests to reflect this. `pytest` was quickly run locally and it passed but as I was unclear on the testing, commit 947923e5ddd6a5b07cb7197aec5f54fa42dbe542 can be changed. 

This PR can be merged as it but it can be edited by the maintainers to add a check if necessary. 

This script is really useful thanks for creating!
-Jake
